### PR TITLE
Add load more pagination to chart view

### DIFF
--- a/assets/css/wakilisha-charts.css
+++ b/assets/css/wakilisha-charts.css
@@ -93,6 +93,9 @@ body.single-chart nav{margin-top:0}
 .waki-mini-btn{margin-top:10px;border:1px solid #84c241;background:#84c241;color:#fff;border-radius:6px;padding:6px 10px;cursor:pointer;display:inline-flex;align-items:center;gap:6px}
 .waki-mini-btn .chev{transition:transform .2s}
 .waki-mini-btn.open .chev{transform:rotate(180deg)}
+.waki-load-wrap{text-align:center;margin:10px 0}
+.waki-load-more{border:1px solid #84c241;background:#84c241;color:#fff;border-radius:6px;padding:8px 16px;cursor:pointer}
+.waki-load-more:hover{background:#6ca32f;border-color:#6ca32f}
 .waki-hist-mini{margin-top:10px;background:#fff;border:1px solid #e5e7eb;border-radius:8px;padding:10px}
 .waki-spark-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch;border:1px dashed #e5e7eb;border-radius:6px;padding:6px}
 .waki-spark{display:block}

--- a/assets/js/wakilisha-charts.js
+++ b/assets/js/wakilisha-charts.js
@@ -52,6 +52,21 @@ document.addEventListener('click',function(e){
   });
 });
 
+// Load more tracks (10 at a time)
+document.addEventListener('click', function(e){
+  const btn = e.target.closest('.waki-load-more'); if(!btn) return;
+  const wrap = btn.closest('.waki-load-wrap'); if(!wrap) return;
+  const nextChunk = wrap.nextElementSibling;
+  if(nextChunk && nextChunk.classList.contains('waki-chunk')){
+    nextChunk.style.display = '';
+    wrap.style.display = 'none';
+    const nextWrap = nextChunk.nextElementSibling;
+    if(nextWrap && nextWrap.classList.contains('waki-load-wrap')){
+      nextWrap.style.display = '';
+    }
+  }
+});
+
 // Toggle mini history
 document.addEventListener('click',function(e){
   const b = e.target.closest('[data-show-history]'); if(!b) return;

--- a/includes/class-waki-charts.php
+++ b/includes/class-waki-charts.php
@@ -1,4 +1,3 @@
-
 <?php
 if (!defined('ABSPATH')) exit;
 final class Waki_Charts {

--- a/templates/latest-chart.php
+++ b/templates/latest-chart.php
@@ -33,10 +33,21 @@
             $firstList = true;
             foreach($dates as $d):
               $rows = $this->get_chart_rows($chart_key,$d, $limit, ($d===$first_date)?$sid:'');
-              if (!$rows) continue; ?>
+              if (!$rows) continue;
+              $chunks = array_chunk($rows, 10);
+              ?>
               <div class="waki-list" data-for-date="<?php echo esc_attr($d); ?>" style="<?php echo $firstList?'':'display:none'; ?>">
-                <?php foreach($rows as $i=>$r){
-                    echo $this->render_entry_row($r, $chart_key, $d);
+                <?php foreach($chunks as $ci => $chunk){
+                    $hidden = $ci === 0 ? '' : 'style="display:none"';
+                    echo '<div class="waki-chunk" '.$hidden.'>';
+                    foreach($chunk as $r){
+                        echo $this->render_entry_row($r, $chart_key, $d);
+                    }
+                    echo '</div>';
+                    if($ci < count($chunks)-1){
+                        $btn_style = $ci === 0 ? '' : 'style="display:none"';
+                        echo '<div class="waki-load-wrap" '.$btn_style.'><button class="waki-load-more">'.esc_html__('Load more', 'wakilisha-charts').'</button></div>';
+                    }
                 } ?>
               </div>
             <?php $firstList=false; endforeach; ?>


### PR DESCRIPTION
## Summary
- Paginate chart track lists in groups of 10 with "Load more" buttons
- Add front-end logic to reveal additional track chunks on demand
- Style new pagination controls for consistency
- Remove stray newline in main class to eliminate top-of-page gap

## Testing
- `php -l includes/class-waki-charts.php`
- `php -l templates/latest-chart.php`
- `node --check assets/js/wakilisha-charts.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b755d24084832c9b3662d775abc07f