### PR TITLE
Add load more pagination and hero improvements

### DIFF
--- a/assets/css/wakilisha-charts.css
+++ b/assets/css/wakilisha-charts.css
@@ -9,29 +9,37 @@ body.single-chart nav{margin-top:0}
 .waki-wrap.waki-fw{max-width:none}
 .waki-arch-title{margin:0 0 6px}
 
-/* HERO (single chart) */
-.waki-chart-hero{
+/* HERO */
+.waki-chart-hero,
+.waki-archive-hero{
   position:relative;
-  text-align:center;
-  display:flex;
-  flex-direction:column;
-  justify-content:center;
-  align-items:center;
-  padding:calc(var(--header-h,0px) + 40px) 20px 60px;
-  margin:0;
-  min-height:60vh;
+  margin:var(--header-h,0px) 0 0;
+  aspect-ratio:47/20;
   background:#111 no-repeat center/cover;
-  background-image:var(--hero);
+  background-image:var(--hero,none);
   color:#fff;
   border-radius:0;
   overflow:hidden;
+  text-align:center;
 }
-.waki-chart-hero::before{
+.waki-archive-hero{background:#111827 no-repeat center/cover}
+.waki-chart-hero::before,
+.waki-archive-hero::before{
   content:"";
   position:absolute;inset:0;
   background:linear-gradient(180deg, rgba(0,0,0,.85), rgba(0,0,0,.45) 40%, rgba(0,0,0,.85));
 }
-.waki-hero-inner{position:relative; z-index:1; padding:24px; color:#fff; display:flex; flex-direction:column; justify-content:center; align-items:center; text-align:center;}
+.waki-hero-inner{
+  position:absolute;
+  inset:40px 20px 60px;
+  color:#fff;
+  display:flex;
+  flex-direction:column;
+  justify-content:center;
+  align-items:center;
+  text-align:center;
+  z-index:1;
+}
 .waki-chart-hero .waki-hero-title,
 .waki-chart-hero .waki-hero-sub,
 .waki-chart-hero .waki-hero-meta,
@@ -93,6 +101,9 @@ body.single-chart nav{margin-top:0}
 .waki-mini-btn{margin-top:10px;border:1px solid #84c241;background:#84c241;color:#fff;border-radius:6px;padding:6px 10px;cursor:pointer;display:inline-flex;align-items:center;gap:6px}
 .waki-mini-btn .chev{transition:transform .2s}
 .waki-mini-btn.open .chev{transform:rotate(180deg)}
+.waki-load-wrap{text-align:center;margin:10px 0}
+.waki-load-more{border:1px solid #84c241;background:#84c241;color:#fff;border-radius:6px;padding:8px 16px;cursor:pointer}
+.waki-load-more:hover{background:#6ca32f;border-color:#6ca32f}
 .waki-hist-mini{margin-top:10px;background:#fff;border:1px solid #e5e7eb;border-radius:8px;padding:10px}
 .waki-spark-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch;border:1px dashed #e5e7eb;border-radius:6px;padding:6px}
 .waki-spark{display:block}
@@ -102,8 +113,6 @@ body.single-chart nav{margin-top:0}
 .waki-mini-table th,.waki-mini-table td{border-top:1px solid #eee;padding:4px 6px;text-align:left}
 
 /* Archive layout — center column (2/4) */
-.waki-archive-hero{position:relative;text-align:center;display:flex;flex-direction:column;justify-content:center;align-items:center;padding:calc(var(--header-h,0px) + 40px) 20px 60px;margin:0;min-height:60vh;background:#111827 no-repeat center/cover;background-image:var(--hero,none);color:#fff;border-radius:0;overflow:hidden}
-.waki-archive-hero::before{content:"";position:absolute;inset:0;background:linear-gradient(180deg, rgba(0,0,0,.85), rgba(0,0,0,.45) 40%, rgba(0,0,0,.85));}
 #waki-archive .waki-archive-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:24px}
 .waki-arch-card{background:#fff;border:1px solid #e5e7eb;border-radius:16px;overflow:hidden;display:flex;flex-direction:column;color:#111}
 .waki-arch-card .cover{padding-top:56%;background-size:cover;background-position:center}
@@ -120,7 +129,6 @@ body.single-chart nav{margin-top:0}
     padding-left:0;
     padding-right:0;
   }
-  .waki-archive-hero{padding:calc(var(--header-h,0px) + 30px) 16px 40px;min-height:70vh}
   #waki-archive .waki-archive-grid{
       display:flex;
       overflow-x:auto;
@@ -183,8 +191,9 @@ body.single-chart nav{margin-top:0}
 .artist-videos .video-item a{display:block;color:inherit;text-decoration:none}
 
 @media (max-width:720px){
+  .waki-chart-hero,
+  .waki-archive-hero{aspect-ratio:9/16}
   .waki-wrap{padding:12px}
-  .waki-chart-hero{padding:calc(var(--header-h,0px) + 30px) 16px 40px;min-height:70vh;margin:0}
   .waki-entry-thumb{width:48px;height:48px;flex:0 0 48px}
   .waki-entry-main .ttl{font-size:15px}
   .waki-entry-main .art{font-size:13px}

--- a/assets/js/wakilisha-charts.js
+++ b/assets/js/wakilisha-charts.js
@@ -52,6 +52,21 @@ document.addEventListener('click',function(e){
   });
 });
 
+// Load more tracks (10 at a time)
+document.addEventListener('click', function(e){
+  const btn = e.target.closest('.waki-load-more'); if(!btn) return;
+  const wrap = btn.closest('.waki-load-wrap'); if(!wrap) return;
+  const nextChunk = wrap.nextElementSibling;
+  if(nextChunk && nextChunk.classList.contains('waki-chunk')){
+    nextChunk.style.display = '';
+    wrap.style.display = 'none';
+    const nextWrap = nextChunk.nextElementSibling;
+    if(nextWrap && nextWrap.classList.contains('waki-load-wrap')){
+      nextWrap.style.display = '';
+    }
+  }
+});
+
 // Toggle mini history
 document.addEventListener('click',function(e){
   const b = e.target.closest('[data-show-history]'); if(!b) return;

--- a/includes/class-waki-charts.php
+++ b/includes/class-waki-charts.php
@@ -1,4 +1,3 @@
-
 <?php
 if (!defined('ABSPATH')) exit;
 final class Waki_Charts {
@@ -10,7 +9,7 @@ final class Waki_Charts {
     const TZ         = 'Africa/Nairobi';
     const API_BASE   = 'https://api.spotify.com';
     const AUTH_URL   = 'https://accounts.spotify.com/api/token';
-    const VER        = '2.3';
+    const VER        = '3.0';
     const ARCHIVE_INTRO = 'waki_archive_intro';
 
     // CPT
@@ -601,7 +600,10 @@ final class Waki_Charts {
             $opts['post_category']   = sanitize_text_field($_POST['post_category'] ?? 'Charts');
             $opts['archive_hero_img']= esc_url_raw($_POST['archive_hero_img'] ?? '');
             $opts['hero_img_size']   = sanitize_key($_POST['hero_img_size'] ?? 'full');
-            update_option(self::OPTS,$opts); $saved=true;
+            $intro                   = sanitize_textarea_field($_POST['archive_intro'] ?? '');
+            update_option(self::OPTS,$opts);
+            update_option(self::ARCHIVE_INTRO, $intro);
+            $saved=true;
         }
 
         if (!empty($_POST[self::SLUG.'_purge'])){
@@ -664,10 +666,18 @@ final class Waki_Charts {
             <h2><?php esc_html_e('Archive', 'wakilisha-charts'); ?></h2>
             <table class="form-table">
               <tr>
+                <th><?php esc_html_e('Intro Text', 'wakilisha-charts'); ?></th>
+                <td>
+                  <?php $intro = get_option(self::ARCHIVE_INTRO, $this->default_archive_intro()); ?>
+                  <textarea name="archive_intro" class="large-text" rows="3"><?php echo esc_textarea($intro); ?></textarea>
+                </td>
+              </tr>
+              <tr>
                 <th><?php esc_html_e('Archive Hero Image', 'wakilisha-charts'); ?></th>
                 <td>
                   <input id="waki_archive_hero_img" class="regular-text" name="archive_hero_img" value="<?php echo esc_attr($opts['archive_hero_img']);?>">
                   <button class="button waki-upload-hero"><?php esc_html_e('Select Image', 'wakilisha-charts'); ?></button>
+                  <p class="description"><?php esc_html_e('Use a 2.35:1 image for desktop and 9:16 for mobile to fill the hero area.', 'wakilisha-charts'); ?></p>
                 </td>
               </tr>
               <tr>
@@ -2945,7 +2955,7 @@ endif; ?>
 
         ob_start();
         include WAKI_CHARTS_DIR . 'templates/artist-profile.php';
-        return ob_get_clean();
+        return ltrim(ob_get_clean());
     }
 
     public function force_single_content($content){
@@ -3033,7 +3043,7 @@ endif; ?>
 
         ob_start();
         include WAKI_CHARTS_DIR . 'templates/latest-chart.php';
-        return ob_get_clean();
+        return ltrim(ob_get_clean());
     }
 
     /* ===== Shortcode: Archive ===== */
@@ -3069,7 +3079,7 @@ endif; ?>
 
         ob_start();
         include WAKI_CHARTS_DIR . 'templates/charts-archive.php';
-        return ob_get_clean();
+        return ltrim(ob_get_clean());
     }
 
     /* ===== Entry rendering with NEW tag rule + interactive history ===== */
@@ -3108,7 +3118,7 @@ endif; ?>
 
         ob_start();
         include WAKI_CHARTS_DIR . 'templates/history-mini.php';
-        return ob_get_clean();
+        return ltrim(ob_get_clean());
     }
 
     private function render_entry_row($r, $chart_key, $chart_date){
@@ -3199,7 +3209,7 @@ endif; ?>
           </div>
         </details>
         <?php
-        return ob_get_clean();
+        return ltrim(ob_get_clean());
     }
 
     /* ===== Dry Run core ===== */

--- a/templates/latest-chart.php
+++ b/templates/latest-chart.php
@@ -33,10 +33,21 @@
             $firstList = true;
             foreach($dates as $d):
               $rows = $this->get_chart_rows($chart_key,$d, $limit, ($d===$first_date)?$sid:'');
-              if (!$rows) continue; ?>
+              if (!$rows) continue;
+              $chunks = array_chunk($rows, 10);
+              ?>
               <div class="waki-list" data-for-date="<?php echo esc_attr($d); ?>" style="<?php echo $firstList?'':'display:none'; ?>">
-                <?php foreach($rows as $i=>$r){
-                    echo $this->render_entry_row($r, $chart_key, $d);
+                <?php foreach($chunks as $ci => $chunk){
+                    $hidden = $ci === 0 ? '' : 'style="display:none"';
+                    echo '<div class="waki-chunk" '.$hidden.'>';
+                    foreach($chunk as $r){
+                        echo $this->render_entry_row($r, $chart_key, $d);
+                    }
+                    echo '</div>';
+                    if($ci < count($chunks)-1){
+                        $btn_style = $ci === 0 ? '' : 'style="display:none"';
+                        echo '<div class="waki-load-wrap" '.$btn_style.'><button class="waki-load-more">'.esc_html__('Load more', 'wakilisha-charts').'</button></div>';
+                    }
                 } ?>
               </div>
             <?php $firstList=false; endforeach; ?>

--- a/wakilisha-charts.php
+++ b/wakilisha-charts.php
@@ -2,7 +2,7 @@
 /**
  * Description: Multi-chart ingest via Playlists or Release Window search; scoring driven by normalized track.popularity; debut/peak (with dates), weekly deltas, recent-weeks viewer, per-track position history, dry-run pipeline with validation & transparency, archive UI, manual Artist Origin (ISO-2) mapping with per-chart origin filter, full artist meta storage, single-chart hero, and Artists admin with filters/CSV import/export/sync.
  * Plugin Name: Wakilisha Charts
- * Version:     2.3
+ * Version:     3.0
  * Author:      WAKILISHA MUSIC GROUP
  * License:     GPLv2 or later
  * Text Domain: wakilisha-charts


### PR DESCRIPTION
## Summary
- Paginate chart track lists in groups of 10 with "Load More" buttons
- Add front-end logic to reveal additional track chunks on demand
- Style new pagination controls for consistency
- Remove stray newline in main class to eliminate top-of-page gap
- Set chart and archive hero images to 2.35:1 on desktop and 9:16 on mobile
- Allow editing of archive hero intro text via settings
- Bump plugin version to 3.0
- Trim buffered shortcode output to eliminate leading newlines above the header

## Testing
- `php -l wakilisha-charts.php`
- `php -l includes/class-waki-charts.php`
- `php -l templates/latest-chart.php`
- `php -l templates/charts-archive.php`
- `node --check assets/js/wakilisha-charts.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b755d24084832c9b3662d775abc07f