### PR TITLE
Restore responsive hero images

### DIFF
--- a/assets/css/wakilisha-charts.css
+++ b/assets/css/wakilisha-charts.css
@@ -9,37 +9,29 @@ body.single-chart nav{margin-top:0}
 .waki-wrap.waki-fw{max-width:none}
 .waki-arch-title{margin:0 0 6px}
 
-/* HERO */
-.waki-chart-hero,
-.waki-archive-hero{
+/* HERO (single chart) */
+.waki-chart-hero{
   position:relative;
-  margin:var(--header-h,0px) 0 0;
-  aspect-ratio:16/9;
-  background:#111 no-repeat center/cover;
-  background-image:var(--hero,none);
-  color:#fff;
-  border-radius:0;
-  overflow:hidden;
   text-align:center;
-}
-.waki-archive-hero{background:#111827 no-repeat center/cover}
-.waki-chart-hero::before,
-.waki-archive-hero::before{
-  content:"";
-  position:absolute;inset:0;
-  background:linear-gradient(180deg, rgba(0,0,0,.85), rgba(0,0,0,.45) 40%, rgba(0,0,0,.85));
-}
-.waki-hero-inner{
-  position:absolute;
-  inset:40px 20px 60px;
-  color:#fff;
   display:flex;
   flex-direction:column;
   justify-content:center;
   align-items:center;
-  text-align:center;
-  z-index:1;
+  padding:calc(var(--header-h,0px) + 40px) 20px 60px;
+  margin:0;
+  min-height:60vh;
+  background:#111 no-repeat center/cover;
+  background-image:var(--hero);
+  color:#fff;
+  border-radius:0;
+  overflow:hidden;
 }
+.waki-chart-hero::before{
+  content:"";
+  position:absolute;inset:0;
+  background:linear-gradient(180deg, rgba(0,0,0,.85), rgba(0,0,0,.45) 40%, rgba(0,0,0,.85));
+}
+.waki-hero-inner{position:relative; z-index:1; padding:24px; color:#fff; display:flex; flex-direction:column; justify-content:center; align-items:center; text-align:center;}
 .waki-chart-hero .waki-hero-title,
 .waki-chart-hero .waki-hero-sub,
 .waki-chart-hero .waki-hero-meta,
@@ -113,6 +105,8 @@ body.single-chart nav{margin-top:0}
 .waki-mini-table th,.waki-mini-table td{border-top:1px solid #eee;padding:4px 6px;text-align:left}
 
 /* Archive layout — center column (2/4) */
+.waki-archive-hero{position:relative;text-align:center;display:flex;flex-direction:column;justify-content:center;align-items:center;padding:calc(var(--header-h,0px) + 40px) 20px 60px;margin:0;min-height:60vh;background:#111827 no-repeat center/cover;background-image:var(--hero,none);color:#fff;border-radius:0;overflow:hidden}
+.waki-archive-hero::before{content:"";position:absolute;inset:0;background:linear-gradient(180deg, rgba(0,0,0,.85), rgba(0,0,0,.45) 40%, rgba(0,0,0,.85));}
 #waki-archive .waki-archive-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:24px}
 .waki-arch-card{background:#fff;border:1px solid #e5e7eb;border-radius:16px;overflow:hidden;display:flex;flex-direction:column;color:#111}
 .waki-arch-card .cover{padding-top:56%;background-size:cover;background-position:center}
@@ -129,6 +123,7 @@ body.single-chart nav{margin-top:0}
     padding-left:0;
     padding-right:0;
   }
+  .waki-archive-hero{padding:calc(var(--header-h,0px) + 30px) 16px 40px;min-height:70vh}
   #waki-archive .waki-archive-grid{
       display:flex;
       overflow-x:auto;
@@ -192,6 +187,7 @@ body.single-chart nav{margin-top:0}
 
 @media (max-width:720px){
   .waki-wrap{padding:12px}
+  .waki-chart-hero{padding:calc(var(--header-h,0px) + 30px) 16px 40px;min-height:70vh;margin:0}
   .waki-entry-thumb{width:48px;height:48px;flex:0 0 48px}
   .waki-entry-main .ttl{font-size:15px}
   .waki-entry-main .art{font-size:13px}


### PR DESCRIPTION
## Summary
- Revert chart and archive hero sections to responsive layout
- Remove fixed aspect ratio; hero height now driven by content

## Testing
- `php -l wakilisha-charts.php`
- `php -l templates/latest-chart.php`
- `php -l templates/charts-archive.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7662c3268832cb9992df2900e74ab