### PR TITLE
Add chip-based chart filtering

### DIFF
--- a/assets/js/charts.js
+++ b/assets/js/charts.js
@@ -1,0 +1,29 @@
+document.addEventListener('click', function(e){
+  const chip = e.target.closest('.waki-chip[data-country], .waki-chip[data-genre], .waki-chip[data-language]');
+  if(!chip) return;
+  e.preventDefault();
+  const active = window.wakiActiveFilters || {country:null,genre:null,language:null};
+  window.wakiActiveFilters = active;
+  let type, value;
+  if(chip.dataset.country){type='country'; value=chip.dataset.country;}
+  else if(chip.dataset.genre){type='genre'; value=chip.dataset.genre;}
+  else {type='language'; value=chip.dataset.language;}
+  if(active[type] === value){
+    active[type] = null;
+    chip.classList.remove('active');
+  } else {
+    active[type] = value;
+    document.querySelectorAll('.waki-chip[data-' + type + ']').forEach(c=>c.classList.toggle('active', c===chip));
+  }
+  const entries = document.querySelectorAll('[data-chart-item]');
+  entries.forEach(entry => {
+    let show = true;
+    for(const key in active){
+      const val = active[key];
+      if(!val) continue;
+      const attrs = (entry.getAttribute('data-' + key) || '').split(/\s+/);
+      if(!attrs.includes(val)) { show = false; break; }
+    }
+    entry.style.display = show ? '' : 'none';
+  });
+});

--- a/includes/class-waki-charts.php
+++ b/includes/class-waki-charts.php
@@ -878,6 +878,7 @@ final class Waki_Charts {
         $base = plugin_dir_url(WAKI_CHARTS_PLUGIN_FILE);
         wp_register_style(self::SLUG, $base . 'assets/css/wakilisha-charts.css', [], self::VER);
         wp_register_script(self::SLUG, $base . 'assets/js/wakilisha-charts.js', [], self::VER, true);
+        wp_register_script(self::SLUG . '-charts', $base . 'assets/js/charts.js', [], self::VER, true);
     }
 
     public function maybe_enqueue_assets(){

--- a/templates/charts-archive.php
+++ b/templates/charts-archive.php
@@ -1,3 +1,4 @@
+        <?php wp_enqueue_script(Waki_Charts::SLUG . '-charts'); ?>
         <template id="waki-archive-hero">
           <div class="waki-archive-hero"<?php if($hero_img) echo ' style="--hero:url(\''.$hero_img.'\')"'; ?>>
             <div class="waki-hero-inner">
@@ -14,45 +15,47 @@
             <p><?php esc_html_e('No charts yet.', 'wakilisha-charts'); ?></p>
           <?php else: ?>
             <div class="waki-archive-grid"><!-- card container -->
-            <?php while($q->have_posts()): $q->the_post(); ?>
-              <article class="waki-arch-card">
-                <?php
-                  $cid   = get_the_ID();
-                  $key   = get_post_meta($cid,'_waki_chart_key',true);
-                  $date  = get_post_meta($cid,'_waki_chart_date',true);
-                  $sid   = get_post_meta($cid,'_waki_snapshot_id',true);
-                  $rows  = $this->get_chart_rows($key,$date,10,$sid);
-                  $imgs  = array_filter(array_column($rows,'album_image_url'));
-                  $cover = $imgs ? $imgs[array_rand($imgs)] : '';
+              <?php while($q->have_posts()): $q->the_post();
+                $cid   = get_the_ID();
+                $key   = get_post_meta($cid,'_waki_chart_key',true);
+                $date  = get_post_meta($cid,'_waki_chart_date',true);
+                $sid   = get_post_meta($cid,'_waki_snapshot_id',true);
+                $rows  = $this->get_chart_rows($key,$date,10,$sid);
+                $imgs  = array_filter(array_column($rows,'album_image_url'));
+                $cover = $imgs ? $imgs[array_rand($imgs)] : '';
+                if(!$cover){
+                  $cover = get_post_meta($cid,'_waki_cover_url',true);
                   if(!$cover){
-                    $cover = get_post_meta($cid,'_waki_cover_url',true);
-                    if(!$cover){
-                      $thumb = get_the_post_thumbnail_url(null,'large');
-                      if($thumb) $cover = $thumb;
-                    }
+                    $thumb = get_the_post_thumbnail_url(null,'large');
+                    if($thumb) $cover = $thumb;
                   }
+                }
 
-                  $countries = get_the_terms($cid,'waki_country');
-                  if(is_wp_error($countries) || !$countries){ $countries = []; }
-                  $genres = get_the_terms($cid,'waki_genre');
-                  if(is_wp_error($genres) || !$genres){ $genres = []; }
-                  $languages = get_the_terms($cid,'waki_language');
-                  if(is_wp_error($languages) || !$languages){ $languages = []; }
-                  $updated = get_post_modified_time(get_option('date_format'), false, $cid);
-                ?>
-                <a class="cover" href="<?php the_permalink(); ?>"<?php if($cover) echo ' style="background-image:url(\''.esc_url($cover).'\')"'; ?>></a>
-                <div class="inner">
+                $countries = get_the_terms($cid,'waki_country');
+                if(is_wp_error($countries) || !$countries){ $countries = []; }
+                $genres = get_the_terms($cid,'waki_genre');
+                if(is_wp_error($genres) || !$genres){ $genres = []; }
+                $languages = get_the_terms($cid,'waki_language');
+                if(is_wp_error($languages) || !$languages){ $languages = []; }
+                $updated = get_post_modified_time(get_option('date_format'), false, $cid);
+                $country_attr = implode(' ', array_map(fn($t)=>strtoupper($t->slug), $countries));
+                $genre_attr = implode(' ', array_map(fn($t)=>$t->slug, $genres));
+                $lang_attr = implode(' ', array_map(fn($t)=>$t->slug, $languages));
+              ?>
+                <article class="waki-arch-card" data-chart-item data-country="<?php echo esc_attr($country_attr); ?>" data-genre="<?php echo esc_attr($genre_attr); ?>" data-language="<?php echo esc_attr($lang_attr); ?>">
+                  <a class="cover" href="<?php the_permalink(); ?>"<?php if($cover) echo ' style="background-image:url(\''.esc_url($cover).'\')"'; ?>></a>
+                  <div class="inner">
                   <h3><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
                   <p class="meta"><?php echo sprintf(esc_html__('Updated %s', 'wakilisha-charts'), esc_html($updated)); ?></p>
                   <div class="waki-hero-meta">
                     <?php foreach($countries as $c): $code = strtoupper($c->slug); ?>
-                      <a class="waki-chip" href="?country=<?php echo esc_attr($code); ?>" data-filter="country:<?php echo esc_attr($code); ?>"><?php echo esc_html($code); ?></a>
+                      <a class="waki-chip" href="?country=<?php echo esc_attr($code); ?>" data-country="<?php echo esc_attr($code); ?>"><?php echo esc_html($code); ?></a>
                     <?php endforeach; ?>
                     <?php foreach($genres as $g): ?>
-                      <a class="waki-chip" href="?genre=<?php echo esc_attr($g->slug); ?>" data-filter="genre:<?php echo esc_attr($g->slug); ?>"><?php echo esc_html($g->name); ?></a>
+                      <a class="waki-chip" href="?genre=<?php echo esc_attr($g->slug); ?>" data-genre="<?php echo esc_attr($g->slug); ?>"><?php echo esc_html($g->name); ?></a>
                     <?php endforeach; ?>
                     <?php foreach($languages as $l): ?>
-                      <a class="waki-chip" href="?language=<?php echo esc_attr($l->slug); ?>" data-filter="language:<?php echo esc_attr($l->slug); ?>"><?php echo esc_html($l->name); ?></a>
+                      <a class="waki-chip" href="?language=<?php echo esc_attr($l->slug); ?>" data-language="<?php echo esc_attr($l->slug); ?>"><?php echo esc_html($l->name); ?></a>
                     <?php endforeach; ?>
                   </div>
                   <a class="view-link" href="<?php the_permalink(); ?>"><?php esc_html_e('View Chart', 'wakilisha-charts'); ?></a>

--- a/templates/latest-chart.php
+++ b/templates/latest-chart.php
@@ -6,6 +6,8 @@ if (is_wp_error($genres) || !$genres) { $genres = []; }
 $languages = get_the_terms(get_the_ID(), 'waki_language');
 if (is_wp_error($languages) || !$languages) { $languages = []; }
 
+wp_enqueue_script(Waki_Charts::SLUG . '-charts');
+
 $page_title = $atts['title'];
 if ($countries) {
     $page_title = 'Top 50 ';
@@ -34,13 +36,13 @@ $atts['title'] = $page_title;
               <p class="waki-hero-sub"><?php echo sprintf(esc_html__('Featuring %s and more', 'wakilisha-charts'), esc_html($intro_artists)); ?></p>
               <div class="waki-hero-meta">
                 <?php foreach($countries as $c): $code = strtoupper($c->slug); ?>
-                  <a class="waki-chip" href="?country=<?php echo esc_attr($code); ?>" data-filter="country:<?php echo esc_attr($code); ?>"><?php echo esc_html($code); ?></a>
+                  <a class="waki-chip" href="?country=<?php echo esc_attr($code); ?>" data-country="<?php echo esc_attr($code); ?>"><?php echo esc_html($code); ?></a>
                 <?php endforeach; ?>
                 <?php foreach($genres as $g): ?>
-                  <a class="waki-chip" href="?genre=<?php echo esc_attr($g->slug); ?>" data-filter="genre:<?php echo esc_attr($g->slug); ?>"><?php echo esc_html($g->name); ?></a>
+                  <a class="waki-chip" href="?genre=<?php echo esc_attr($g->slug); ?>" data-genre="<?php echo esc_attr($g->slug); ?>"><?php echo esc_html($g->name); ?></a>
                 <?php endforeach; ?>
                 <?php foreach($languages as $l): ?>
-                  <a class="waki-chip" href="?language=<?php echo esc_attr($l->slug); ?>" data-filter="language:<?php echo esc_attr($l->slug); ?>"><?php echo esc_html($l->name); ?></a>
+                  <a class="waki-chip" href="?language=<?php echo esc_attr($l->slug); ?>" data-language="<?php echo esc_attr($l->slug); ?>"><?php echo esc_html($l->name); ?></a>
                 <?php endforeach; ?>
                 <?php if($updated){ ?><span class="waki-chip"><?php echo sprintf(esc_html__('Updated %s', 'wakilisha-charts'), esc_html($updated)); ?></span><?php } ?>
               </div>


### PR DESCRIPTION
## Summary
- Add chart filtering script listening for chip clicks
- Register and enqueue new script in chart templates
- Annotate chips and chart cards with country, genre, and language data attributes for filtering

## Testing
- ✅ `php -l templates/latest-chart.php`
- ✅ `php -l templates/charts-archive.php`
- ✅ `php -l includes/class-waki-charts.php`
- ✅ `node --check assets/js/charts.js`


------
https://chatgpt.com/codex/tasks/task_e_68b84c8b0ba4832c80ad5eecdb042ad1