### PR TITLE
Add taxonomy-aware breadcrumbs

### DIFF
--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -1,0 +1,81 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+/**
+ * Render breadcrumbs for Waki Charts posts.
+ *
+ * Prefers `waki_country` terms and lists ISO-2 codes. When no countries are
+ * assigned it falls back to the `waki_region` hierarchy.
+ *
+ * @param int|\WP_Post|null $post Optional. Post object or ID. Defaults to global post.
+ * @return void Outputs HTML navigation list of breadcrumbs.
+ */
+function waki_chart_breadcrumbs($post = null){
+    $post = get_post($post);
+    if (!$post) {
+        return;
+    }
+
+    $crumbs = [];
+
+    // Home
+    $crumbs[] = [
+        'label' => get_bloginfo('name'),
+        'url'   => home_url('/')
+    ];
+
+    // Charts archive page
+    $archive_url = home_url('/' . Waki_Charts::CPT_SLUG . '/');
+    $crumbs[] = [
+        'label' => __('Charts', 'wakilisha-charts'),
+        'url'   => $archive_url
+    ];
+
+    $countries = get_the_terms($post, 'waki_country');
+    if (!is_wp_error($countries) && $countries) {
+        foreach ($countries as $country) {
+            $crumbs[] = [
+                'label' => strtoupper($country->slug),
+                'url'   => get_term_link($country)
+            ];
+        }
+    } else {
+        $regions = get_the_terms($post, 'waki_region');
+        if (!is_wp_error($regions) && $regions) {
+            $region = $regions[0];
+            $ancestors = array_reverse(get_ancestors($region->term_id, 'waki_region'));
+            foreach ($ancestors as $ancestor_id) {
+                $ancestor = get_term($ancestor_id, 'waki_region');
+                if ($ancestor && !is_wp_error($ancestor)) {
+                    $crumbs[] = [
+                        'label' => $ancestor->name,
+                        'url'   => get_term_link($ancestor)
+                    ];
+                }
+            }
+            $crumbs[] = [
+                'label' => $region->name,
+                'url'   => get_term_link($region)
+            ];
+        }
+    }
+
+    // Current post
+    $crumbs[] = [
+        'label' => get_the_title($post),
+        'url'   => get_permalink($post)
+    ];
+
+    $parts = [];
+    $total = count($crumbs) - 1; // last index
+    foreach ($crumbs as $i => $c) {
+        $label = esc_html($c['label']);
+        if (!empty($c['url']) && $i !== $total) {
+            $parts[] = '<a href="' . esc_url($c['url']) . '">' . $label . '</a>';
+        } else {
+            $parts[] = '<span class="current">' . $label . '</span>';
+        }
+    }
+
+    echo '<nav class="waki-breadcrumbs">' . implode(' &rsaquo; ', $parts) . '</nav>';
+}

--- a/wakilisha-charts.php
+++ b/wakilisha-charts.php
@@ -19,5 +19,6 @@ add_action('init', function(){
 });
 
 require_once WAKI_CHARTS_DIR . 'includes/class-waki-charts.php';
+require_once WAKI_CHARTS_DIR . 'includes/template-tags.php';
 
 Waki_Charts::instance();


### PR DESCRIPTION
## Summary
- load new template tags for breadcrumbs
- render breadcrumbs using waki_country ISO codes or fallback to waki_region hierarchy

## Testing
- `php -l includes/template-tags.php`
- `php -l wakilisha-charts.php`


------
https://chatgpt.com/codex/tasks/task_e_68b84dcfd258832c903043190fb19ff5