### PR TITLE
Add taxonomy archive templates and update genre hierarchy

### DIFF
--- a/includes/class-waki-charts.php
+++ b/includes/class-waki-charts.php
@@ -73,6 +73,7 @@ final class Waki_Charts {
         add_filter('query_vars',            [$this,'add_query_vars']);
         add_action('pre_get_posts',        [$this,'resolve_chart_request']);
         add_filter('template_include',      [$this,'load_artist_template']);
+        add_filter('template_include',      [$this,'load_taxonomy_templates']);
 
         add_action('add_meta_boxes_' . self::CPT, [$this,'add_chart_keys_meta_box']);
         add_action('save_post_' . self::CPT,      [$this,'handle_chart_save'], 10, 3);
@@ -567,7 +568,7 @@ final class Waki_Charts {
                 'singular_name' => __('Genre', 'wakilisha-charts'),
             ],
             'rewrite' => ['slug' => 'genre', 'with_front' => false],
-            'hierarchical' => false,
+            'hierarchical' => true,
         ]));
 
         register_taxonomy('waki_language', [self::CPT], array_merge($common, [
@@ -880,6 +881,19 @@ final class Waki_Charts {
                 wp_enqueue_style(self::SLUG);
                 wp_enqueue_script(self::SLUG);
                 return WAKI_CHARTS_DIR . 'templates/artist-profile.php';
+            }
+        }
+        return $template;
+    }
+
+    public function load_taxonomy_templates($template){
+        if (is_tax(['waki_genre','waki_language','waki_format','waki_country','waki_region'])) {
+            $tax = get_queried_object();
+            if ($tax && isset($tax->taxonomy)) {
+                $file = WAKI_CHARTS_DIR . 'templates/taxonomy-' . $tax->taxonomy . '.php';
+                if (file_exists($file)) {
+                    return $file;
+                }
             }
         }
         return $template;

--- a/templates/taxonomy-waki-term.php
+++ b/templates/taxonomy-waki-term.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Generic template for WAKI taxonomy archives.
+ * Lists chart editions for the queried term with year filter and pagination.
+ */
+
+if (!defined('ABSPATH')) exit;
+
+get_header();
+
+$term  = get_queried_object();
+if (!$term) {
+    get_footer();
+    return;
+}
+
+$year  = isset($_GET['year']) ? intval($_GET['year']) : 0;
+$paged = max(1, get_query_var('paged'));
+
+global $wpdb;
+$years = $wpdb->get_col(
+    $wpdb->prepare(
+        "SELECT DISTINCT YEAR(p.post_date)
+         FROM {$wpdb->posts} p
+         INNER JOIN {$wpdb->term_relationships} tr ON p.ID = tr.object_id
+         INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
+         WHERE tt.taxonomy = %s AND tt.term_id = %d AND p.post_type = %s AND p.post_status = 'publish'
+         ORDER BY YEAR(p.post_date) DESC",
+        $term->taxonomy,
+        $term->term_id,
+        Waki_Charts::CPT
+    )
+);
+
+$args = [
+    'post_type'      => Waki_Charts::CPT,
+    'posts_per_page' => 10,
+    'paged'          => $paged,
+    'tax_query'      => [
+        [
+            'taxonomy' => $term->taxonomy,
+            'terms'    => $term->term_id,
+        ],
+    ],
+];
+if ($year) {
+    $args['year'] = $year;
+}
+
+$q = new WP_Query($args);
+?>
+
+<section class="waki-wrap waki-fw">
+    <header class="waki-term-header">
+        <h1><?php echo esc_html($term->name); ?></h1>
+        <?php if ($years) : ?>
+            <form method="get" id="waki-year-filter">
+                <label for="waki-year-select"><?php esc_html_e('Year:', 'wakilisha-charts'); ?></label>
+                <select id="waki-year-select" name="year" onchange="document.getElementById('waki-year-filter').submit();">
+                    <option value=""><?php esc_html_e('All Years', 'wakilisha-charts'); ?></option>
+                    <?php foreach ($years as $y) : ?>
+                        <option value="<?php echo esc_attr($y); ?>"<?php selected($year, (int) $y); ?>><?php echo esc_html($y); ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </form>
+        <?php endif; ?>
+    </header>
+
+    <?php if ($q->have_posts()) : ?>
+        <ul class="waki-term-list">
+            <?php while ($q->have_posts()) : $q->the_post(); ?>
+                <li><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></li>
+            <?php endwhile; ?>
+        </ul>
+
+        <div class="waki-pager">
+            <?php
+            echo paginate_links([
+                'total'   => $q->max_num_pages,
+                'current' => $paged,
+                'prev_text' => '«',
+                'next_text' => '»',
+            ]);
+            ?>
+        </div>
+    <?php else : ?>
+        <p><?php esc_html_e('No charts found.', 'wakilisha-charts'); ?></p>
+    <?php endif; wp_reset_postdata(); ?>
+</section>
+
+<?php get_footer();

--- a/templates/taxonomy-waki_country.php
+++ b/templates/taxonomy-waki_country.php
@@ -1,0 +1,3 @@
+<?php
+if (!defined('ABSPATH')) exit;
+include __DIR__ . '/taxonomy-waki-term.php';

--- a/templates/taxonomy-waki_format.php
+++ b/templates/taxonomy-waki_format.php
@@ -1,0 +1,3 @@
+<?php
+if (!defined('ABSPATH')) exit;
+include __DIR__ . '/taxonomy-waki-term.php';

--- a/templates/taxonomy-waki_genre.php
+++ b/templates/taxonomy-waki_genre.php
@@ -1,0 +1,3 @@
+<?php
+if (!defined('ABSPATH')) exit;
+include __DIR__ . '/taxonomy-waki-term.php';

--- a/templates/taxonomy-waki_language.php
+++ b/templates/taxonomy-waki_language.php
@@ -1,0 +1,3 @@
+<?php
+if (!defined('ABSPATH')) exit;
+include __DIR__ . '/taxonomy-waki-term.php';

--- a/templates/taxonomy-waki_region.php
+++ b/templates/taxonomy-waki_region.php
@@ -1,0 +1,3 @@
+<?php
+if (!defined('ABSPATH')) exit;
+include __DIR__ . '/taxonomy-waki-term.php';


### PR DESCRIPTION
## Summary
- make `waki_genre` taxonomy hierarchical while keeping other taxonomies flat except `waki_region`
- add taxonomy templates for genres, languages, formats, countries and regions with year dropdown and pagination
- load custom taxonomy templates through `template_include`

## Testing
- `php -l includes/class-waki-charts.php`
- `php -l templates/taxonomy-waki-term.php`
- `php -l templates/taxonomy-waki_genre.php`
- `php -l templates/taxonomy-waki_language.php`
- `php -l templates/taxonomy-waki_format.php`
- `php -l templates/taxonomy-waki_country.php`
- `php -l templates/taxonomy-waki_region.php`


------
https://chatgpt.com/codex/tasks/task_e_68b871201f1c832c8d794cef110ff649