### PR TITLE
Add format hub and calendar navigation

### DIFF
--- a/assets/css/wakilisha-charts.css
+++ b/assets/css/wakilisha-charts.css
@@ -118,6 +118,15 @@ body.single-chart nav{margin-top:0}
 .waki-arch-card .view-link:hover{background:#6ca32f}
 .waki-pager{margin:20px 0;display:flex;justify-content:center}
 
+.waki-calendar{display:flex;flex-wrap:wrap;gap:20px;margin-bottom:20px}
+.waki-cal-month{flex:1 1 220px}
+.waki-cal-table{width:100%;border-collapse:collapse;table-layout:fixed;font-size:12px}
+.waki-cal-table th,.waki-cal-table td{text-align:center;padding:4px}
+.waki-cal-table td a{text-decoration:none;display:block;padding:4px;border-radius:4px;color:inherit}
+.waki-cal-table td.has-chart a{background:#84c241;color:#fff}
+.waki-cal-table td.today a{border:1px solid #84c241}
+.waki-cal-table td.pad{background:transparent}
+
 @media(max-width:600px){
   section#waki-archive.waki-wrap{
     padding-left:0;

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -1,0 +1,5 @@
+document.addEventListener('DOMContentLoaded',function(){
+  var today=new Date().toISOString().split('T')[0];
+  document.querySelectorAll('.waki-calendar td[data-date="'+today+'"]')
+    .forEach(function(td){td.classList.add('today');});
+});

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -79,3 +79,13 @@ function waki_chart_breadcrumbs($post = null){
 
     echo '<nav class="waki-breadcrumbs">' . implode(' &rsaquo; ', $parts) . '</nav>';
 }
+
+/**
+ * Output calendar navigation for a chart format and year.
+ *
+ * @param string $format Format slug.
+ * @param int|null $year Year number, defaults to current.
+ */
+function waki_chart_calendar($format, $year = null){
+    echo Waki_Charts::instance()->get_calendar_html($format, $year);
+}

--- a/templates/calendar.php
+++ b/templates/calendar.php
@@ -1,0 +1,42 @@
+<?php
+if (!defined('ABSPATH')) exit;
+?>
+<div class="waki-calendar" data-format="<?php echo esc_attr($format_slug); ?>" data-year="<?php echo esc_attr($year_num); ?>">
+<?php
+for ($m = 1; $m <= 12; $m++):
+    $first = new DateTime(sprintf('%04d-%02d-01', $year_num, $m));
+    $days_in_month = (int) $first->format('t');
+    $wday = (int) $first->format('N'); // 1 (Mon) - 7 (Sun)
+?>
+  <div class="waki-cal-month">
+    <h4><?php echo esc_html($first->format('F')); ?></h4>
+    <table class="waki-cal-table">
+      <thead>
+        <tr>
+          <th>Mon</th><th>Tue</th><th>Wed</th><th>Thu</th><th>Fri</th><th>Sat</th><th>Sun</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+<?php
+    for ($i = 1; $i < $wday; $i++) echo '<td class="pad"></td>';
+    for ($d = 1; $d <= $days_in_month; $d++):
+        $date = sprintf('%04d-%02d-%02d', $year_num, $m, $d);
+        $monday = date('Y-m-d', strtotime($date . ' monday this week'));
+        $cls = [];
+        if (isset($week_lookup[$monday])) $cls[] = 'has-chart';
+        $cls_attr = $cls ? ' class="' . esc_attr(implode(' ', $cls)) . '"' : '';
+        echo '<td data-date="' . esc_attr($date) . '"' . $cls_attr . '><a href="' . esc_url(home_url('/' . Waki_Charts::CPT_SLUG . '/' . $format_slug . '/' . $monday . '/')) . '">' . $d . '</a></td>';
+        if (($wday + $d - 1) % 7 == 0 && $d != $days_in_month) echo '</tr><tr>';
+    endfor;
+    $last = ($wday + $days_in_month - 1) % 7;
+    if ($last !== 0) {
+        for ($i = $last + 1; $i <= 7; $i++) echo '<td class="pad"></td>';
+    }
+?>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+<?php endfor; ?>
+</div>

--- a/templates/hub-format.php
+++ b/templates/hub-format.php
@@ -1,0 +1,90 @@
+<?php
+if (!defined('ABSPATH')) exit;
+get_header();
+$format = sanitize_title(get_query_var('waki_chart_format'));
+if (!$format) {
+    get_footer();
+    return;
+}
+$year  = isset($_GET['year']) ? intval($_GET['year']) : 0;
+$paged = max(1, get_query_var('paged'));
+
+global $wpdb;
+$years = $wpdb->get_col(
+    $wpdb->prepare(
+        "SELECT DISTINCT YEAR(pm.meta_value)
+         FROM {$wpdb->postmeta} pm
+         INNER JOIN {$wpdb->postmeta} pf ON pm.post_id = pf.post_id
+         INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+         WHERE pm.meta_key = '_waki_week_start'
+           AND pf.meta_key = '_waki_format'
+           AND pf.meta_value = %s
+           AND p.post_type = %s AND p.post_status = 'publish'
+         ORDER BY YEAR(pm.meta_value) DESC",
+        $format,
+        Waki_Charts::CPT
+    )
+);
+
+$args = [
+    'post_type'      => Waki_Charts::CPT,
+    'posts_per_page' => 20,
+    'paged'          => $paged,
+    'post_status'    => 'publish',
+    'meta_key'       => '_waki_week_start',
+    'orderby'        => 'meta_value',
+    'order'          => 'DESC',
+    'meta_query'     => [
+        [ 'key' => '_waki_format', 'value' => $format ],
+    ],
+];
+if ($year) {
+    $args['meta_query'][] = [
+        'key'     => '_waki_week_start',
+        'value'   => [$year . '-01-01', $year . '-12-31'],
+        'compare' => 'BETWEEN',
+        'type'    => 'DATE',
+    ];
+}
+$q = new WP_Query($args);
+?>
+<section class="waki-wrap waki-fw">
+    <header class="waki-term-header">
+        <h1><?php echo esc_html(ucwords(str_replace('-', ' ', $format))); ?></h1>
+        <?php if ($years) : ?>
+            <form method="get" id="waki-year-filter">
+                <label for="waki-year-select"><?php esc_html_e('Year:', 'wakilisha-charts'); ?></label>
+                <select id="waki-year-select" name="year" onchange="document.getElementById('waki-year-filter').submit();">
+                    <option value=""><?php esc_html_e('All Years', 'wakilisha-charts'); ?></option>
+                    <?php foreach ($years as $y) : ?>
+                        <option value="<?php echo esc_attr($y); ?>"<?php selected($year, (int) $y); ?>><?php echo esc_html($y); ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </form>
+        <?php endif; ?>
+    </header>
+
+    <?php waki_chart_calendar($format, $year ?: date('Y')); ?>
+
+    <?php if ($q->have_posts()) : ?>
+        <ul class="waki-term-list">
+            <?php while ($q->have_posts()) : $q->the_post(); ?>
+                <li><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></li>
+            <?php endwhile; ?>
+        </ul>
+
+        <div class="waki-pager">
+            <?php
+            echo paginate_links([
+                'total'   => $q->max_num_pages,
+                'current' => $paged,
+                'prev_text' => '«',
+                'next_text' => '»',
+            ]);
+            ?>
+        </div>
+    <?php else : ?>
+        <p><?php esc_html_e('No charts found.', 'wakilisha-charts'); ?></p>
+    <?php endif; wp_reset_postdata(); ?>
+</section>
+<?php get_footer();


### PR DESCRIPTION
## Summary
- Load new hub-format template on format archives and enqueue calendar assets
- Add calendar generation with transient caching and integrate into single chart pages
- Provide hub-format template, calendar partial, styles, and lightweight JS

## Testing
- `php -l includes/class-waki-charts.php`
- `php -l includes/template-tags.php`
- `php -l templates/calendar.php`
- `php -l templates/hub-format.php`


------
https://chatgpt.com/codex/tasks/task_e_68b87531a288832c8b28e17eec664f92