### PR TITLE
Handle daily charts privately and restrict public listings to weekly posts

### DIFF
--- a/templates/hub-format.php
+++ b/templates/hub-format.php
@@ -36,10 +36,11 @@ $args = [
     'order'          => 'DESC',
     'meta_query'     => [
         [ 'key' => '_waki_format', 'value' => $format ],
+        [ 'key' => '_waki_week_start', 'compare' => 'EXISTS' ],
     ],
 ];
 if ($year) {
-    $args['meta_query'][] = [
+    $args['meta_query'][1] = [
         'key'     => '_waki_week_start',
         'value'   => [$year . '-01-01', $year . '-12-31'],
         'compare' => 'BETWEEN',


### PR DESCRIPTION
## Summary
- Register non-public `wakilisha_daily_chart` CPT for daily chart data
- Create daily charts as private and tag weekly charts with `_waki_week_start`
- Filter chart queries and templates so only weekly posts surface publicly

## Testing
- `php -l includes/class-waki-charts.php`
- `php -l templates/hub-format.php`
- `php -l templates/taxonomy-waki-term.php`


------
https://chatgpt.com/codex/tasks/task_e_68b87a75f4e0832cb7fabb295fabbf8d