### PR TITLE
Add single chart template with week navigation and fallback

### DIFF
--- a/includes/class-waki-charts.php
+++ b/includes/class-waki-charts.php
@@ -78,6 +78,7 @@ final class Waki_Charts {
         add_filter('template_include',      [$this,'load_artist_template']);
         add_filter('template_include',      [$this,'load_taxonomy_templates']);
         add_filter('template_include',      [$this,'load_chart_archive_template']);
+        add_filter('template_include',      [$this,'load_chart_single_template']);
 
         add_action('add_meta_boxes_' . self::CPT, [$this,'add_chart_keys_meta_box']);
         add_action('add_meta_boxes_' . self::CPT, [$this,'add_chart_dates_meta_box']);
@@ -1056,6 +1057,19 @@ final class Waki_Charts {
             } else {
                 $file = WAKI_CHARTS_DIR . 'templates/archive-' . self::CPT . '.php';
             }
+            if (file_exists($file)) {
+                return $file;
+            }
+        }
+        return $template;
+    }
+
+    public function load_chart_single_template($template){
+        if (
+            is_singular(self::CPT) ||
+            (is_404() && get_query_var('waki_chart_format') && get_query_var('waki_chart_date'))
+        ) {
+            $file = WAKI_CHARTS_DIR . 'templates/single-' . self::CPT . '.php';
             if (file_exists($file)) {
                 return $file;
             }

--- a/templates/single-wakilisha_chart.php
+++ b/templates/single-wakilisha_chart.php
@@ -1,0 +1,79 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+get_header();
+
+$format = sanitize_title(get_query_var('waki_chart_format'));
+$date   = sanitize_text_field(get_query_var('waki_chart_date'));
+$has_chart = have_posts();
+
+if ($has_chart) {
+    the_post();
+    $week   = sanitize_text_field(get_post_meta(get_the_ID(), '_waki_week_start', true));
+    $format = sanitize_title(get_post_meta(get_the_ID(), '_waki_format', true)) ?: $format;
+} else {
+    $week = $date;
+}
+
+function waki_chart_exact($format, $week) {
+    $posts = get_posts([
+        'post_type'      => Waki_Charts::CPT,
+        'post_status'    => 'publish',
+        'posts_per_page' => 1,
+        'fields'         => 'ids',
+        'meta_query'     => [
+            ['key' => '_waki_format', 'value' => $format],
+            ['key' => '_waki_week_start', 'value' => $week],
+        ],
+    ]);
+    return $posts ? $posts[0] : 0;
+}
+
+function waki_chart_adjacent($format, $week, $compare, $order) {
+    $posts = get_posts([
+        'post_type'      => Waki_Charts::CPT,
+        'post_status'    => 'publish',
+        'posts_per_page' => 1,
+        'fields'         => 'ids',
+        'meta_key'       => '_waki_week_start',
+        'orderby'        => 'meta_value',
+        'order'          => $order,
+        'meta_query'     => [
+            ['key' => '_waki_format', 'value' => $format],
+            ['key' => '_waki_week_start', 'value' => $week, 'compare' => $compare, 'type' => 'DATE'],
+        ],
+    ]);
+    return $posts ? $posts[0] : 0;
+}
+
+$prev_link = $next_link = '';
+if ($format && $week) {
+    $ts = strtotime($week);
+    if ($has_chart && $ts) {
+        $prev_id = waki_chart_exact($format, date('Y-m-d', $ts - WEEK_IN_SECONDS));
+        $next_id = waki_chart_exact($format, date('Y-m-d', $ts + WEEK_IN_SECONDS));
+    } else {
+        $prev_id = waki_chart_adjacent($format, $week, '<', 'DESC');
+        $next_id = waki_chart_adjacent($format, $week, '>', 'ASC');
+    }
+    $prev_link = $prev_id ? get_permalink($prev_id) : '';
+    $next_link = $next_id ? get_permalink($next_id) : '';
+}
+?>
+<section class="waki-wrap waki-fw">
+    <?php if ($has_chart) : ?>
+        <?php the_content(); ?>
+    <?php else : ?>
+        <p><?php esc_html_e('No edition this week.', 'wakilisha-charts'); ?></p>
+    <?php endif; ?>
+
+    <nav class="waki-week-nav">
+        <?php if ($prev_link) : ?>
+            <a class="waki-prev" href="<?php echo esc_url($prev_link); ?>">&laquo; <?php esc_html_e('Previous Week', 'wakilisha-charts'); ?></a>
+        <?php endif; ?>
+        <?php if ($next_link) : ?>
+            <a class="waki-next" href="<?php echo esc_url($next_link); ?>"><?php esc_html_e('Next Week', 'wakilisha-charts'); ?> &raquo;</a>
+        <?php endif; ?>
+    </nav>
+</section>
+<?php get_footer();


### PR DESCRIPTION
## Summary
- Load a dedicated template for individual chart editions.
- Support adjacent week navigation and nearest links when an edition is missing.

## Testing
- `php -l templates/single-wakilisha_chart.php`
- `php -l includes/class-waki-charts.php`


------
https://chatgpt.com/codex/tasks/task_e_68b87ddfd8bc832cb628e72370f3cbff