### PR TITLE
Display archive chips over cover image

### DIFF
--- a/assets/css/wakilisha-charts.css
+++ b/assets/css/wakilisha-charts.css
@@ -109,7 +109,9 @@ body.single-chart nav{margin-top:0}
 .waki-archive-hero::before{content:"";position:absolute;inset:0;background:linear-gradient(180deg, rgba(0,0,0,.85), rgba(0,0,0,.45) 40%, rgba(0,0,0,.85));}
 #waki-archive .waki-archive-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:24px}
 .waki-arch-card{background:#fff;border:1px solid #e5e7eb;border-radius:16px;overflow:hidden;display:flex;flex-direction:column;color:#111}
-.waki-arch-card .cover{padding-top:56%;background-size:cover;background-position:center}
+.waki-arch-card .cover{position:relative;padding-top:56%;background-size:cover;background-position:center}
+.waki-arch-card .cover .waki-hero-meta{position:absolute;left:8px;bottom:8px;display:flex;flex-wrap:wrap;gap:8px;justify-content:flex-start}
+.waki-arch-card .cover .waki-chip{background:rgba(0,0,0,.6);color:#fff;border-color:rgba(255,255,255,.2)}
 .waki-arch-card .inner{padding:16px;display:flex;flex-direction:column;flex:1}
 .waki-arch-card h3{margin:0 0 8px;font-size:20px}
 .waki-arch-card h3 a{text-decoration:none;color:inherit}

--- a/templates/charts-archive.php
+++ b/templates/charts-archive.php
@@ -43,21 +43,22 @@
                 $lang_attr = implode(' ', array_map(fn($t)=>$t->slug, $languages));
               ?>
                 <article class="waki-arch-card" data-chart-item data-country="<?php echo esc_attr($country_attr); ?>" data-genre="<?php echo esc_attr($genre_attr); ?>" data-language="<?php echo esc_attr($lang_attr); ?>">
-                  <a class="cover" href="<?php the_permalink(); ?>"<?php if($cover) echo ' style="background-image:url(\''.esc_url($cover).'\')"'; ?>></a>
+                  <a class="cover" href="<?php the_permalink(); ?>"<?php if($cover) echo ' style="background-image:url(\''.esc_url($cover).'\')"'; ?>>
+                    <div class="waki-hero-meta">
+                      <?php foreach($countries as $c): $code = strtoupper($c->slug); ?>
+                        <a class="waki-chip" href="?country=<?php echo esc_attr($code); ?>" data-country="<?php echo esc_attr($code); ?>"><?php echo esc_html($code); ?></a>
+                      <?php endforeach; ?>
+                      <?php foreach($genres as $g): ?>
+                        <a class="waki-chip" href="?genre=<?php echo esc_attr($g->slug); ?>" data-genre="<?php echo esc_attr($g->slug); ?>"><?php echo esc_html($g->name); ?></a>
+                      <?php endforeach; ?>
+                      <?php foreach($languages as $l): ?>
+                        <a class="waki-chip" href="?language=<?php echo esc_attr($l->slug); ?>" data-language="<?php echo esc_attr($l->slug); ?>"><?php echo esc_html($l->name); ?></a>
+                      <?php endforeach; ?>
+                    </div>
+                  </a>
                   <div class="inner">
                   <h3><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
                   <p class="meta"><?php echo sprintf(esc_html__('Updated %s', 'wakilisha-charts'), esc_html($updated)); ?></p>
-                  <div class="waki-hero-meta">
-                    <?php foreach($countries as $c): $code = strtoupper($c->slug); ?>
-                      <a class="waki-chip" href="?country=<?php echo esc_attr($code); ?>" data-country="<?php echo esc_attr($code); ?>"><?php echo esc_html($code); ?></a>
-                    <?php endforeach; ?>
-                    <?php foreach($genres as $g): ?>
-                      <a class="waki-chip" href="?genre=<?php echo esc_attr($g->slug); ?>" data-genre="<?php echo esc_attr($g->slug); ?>"><?php echo esc_html($g->name); ?></a>
-                    <?php endforeach; ?>
-                    <?php foreach($languages as $l): ?>
-                      <a class="waki-chip" href="?language=<?php echo esc_attr($l->slug); ?>" data-language="<?php echo esc_attr($l->slug); ?>"><?php echo esc_html($l->name); ?></a>
-                    <?php endforeach; ?>
-                  </div>
                   <a class="view-link" href="<?php the_permalink(); ?>"><?php esc_html_e('View Chart', 'wakilisha-charts'); ?></a>
                 </div>
               </article>


### PR DESCRIPTION
## Summary
- Move chart archive meta chips inside the cover anchor so badges overlay the featured image.
- Style archive cover to position hero meta and darken chip backgrounds for contrast.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b881d2bf84832c892676f394618155