### PR TITLE
Skip validation when trashing charts

### DIFF
--- a/includes/class-waki-charts.php
+++ b/includes/class-waki-charts.php
@@ -519,6 +519,10 @@ final class Waki_Charts {
         if($post->post_type!==self::CPT) return;
         if(wp_is_post_revision($post_id)) return;
 
+        $action = $_REQUEST['action'] ?? '';
+        $status = get_post_status($post_id);
+        if($status === 'trash' || $action === 'trash') return;
+
         $errors=[];
 
         $week_raw = sanitize_text_field($_POST['_waki_week_start'] ?? '');


### PR DESCRIPTION
## Summary
- Avoid running validation when a chart post is being trashed

## Testing
- `php -l includes/class-waki-charts.php`


------
https://chatgpt.com/codex/tasks/task_e_68b882469a60832cbb0a898e149a406c