### PR TITLE
Remove region references from UI strings

### DIFF
--- a/includes/class-waki-charts.php
+++ b/includes/class-waki-charts.php
@@ -2365,7 +2365,6 @@ endif; ?>
               <table class="widefat striped">
                 <tbody>
                   <tr><th>Countries</th><td><input type="text" name="meta_countries" class="regular-text" value="<?php echo esc_attr(implode(', ', $report['parsed_meta']['countries'] ?? [])); ?>"></td></tr>
-                  <tr><th>Region</th><td><input type="text" name="meta_region" class="regular-text" value="<?php echo esc_attr($report['parsed_meta']['region'] ?? ''); ?>"></td></tr>
                   <tr><th>Genres</th><td><input type="text" name="meta_genres" class="regular-text" value="<?php echo esc_attr(implode(', ', $report['parsed_meta']['genres'] ?? [])); ?>"></td></tr>
                   <tr><th>Languages</th><td><input type="text" name="meta_languages" class="regular-text" value="<?php echo esc_attr(implode(', ', $report['parsed_meta']['languages'] ?? [])); ?>"></td></tr>
                   <tr><th>Format</th><td><input type="text" name="meta_format" class="regular-text" value="<?php echo esc_attr($report['parsed_meta']['format'] ?? ''); ?>"></td></tr>
@@ -4120,7 +4119,7 @@ endif; ?>
     }
 
     private function default_archive_intro(){
-        return __('From club heaters to quiet stunners, this is a living record of Kenyan music, tracked weekly, filtered by region and genre, and more.', 'wakilisha-charts');
+        return __('From club heaters to quiet stunners, this is a living record of Kenyan music, tracked weekly, filtered by genre and more.', 'wakilisha-charts');
     }
 
     public function register_rest_routes(){

--- a/languages/wakilisha-charts.pot
+++ b/languages/wakilisha-charts.pot
@@ -301,7 +301,7 @@ msgstr ""
 #: templates/charts-archive.php:5
 msgid ""
 "From club heaters to quiet stunners, this is a living record of Kenyan "
-"music, tracked weekly, filtered by region and genre, and more."
+"music, tracked weekly, filtered by genre and more."
 msgstr ""
 
 #: templates/charts-archive.php:13
@@ -313,10 +313,6 @@ msgstr ""
 msgid "Updated %s"
 msgstr ""
 
-#: templates/charts-archive.php:45
-#, php-format
-msgid "Region: %s"
-msgstr ""
 
 #: templates/charts-archive.php:46
 #, php-format


### PR DESCRIPTION
## Summary
- Drop region mention from default archive intro message
- Remove Region field from Parsed Metadata form
- Update translation template to omit region-based filtering strings

## Testing
- `php -l includes/class-waki-charts.php`
- `php -l wakilisha-charts.php`


------
https://chatgpt.com/codex/tasks/task_e_68b886065cb4832c950476d81c0cb08f