### PR TITLE
feat: set chart image alt text

### DIFF
--- a/includes/class-waki-charts.php
+++ b/includes/class-waki-charts.php
@@ -3888,7 +3888,7 @@ endif; ?>
             </div>
             <div class="waki-vbar" aria-hidden="true"></div>
             <?php if($has_thumb): ?>
-              <div class="waki-entry-thumb"><img src="<?php echo $thumb; ?>" alt="" loading="lazy"></div>
+              <div class="waki-entry-thumb"><img src="<?php echo $thumb; ?>" alt="<?php echo esc_attr($title.' — '.$artist); ?>" loading="lazy"></div>
             <?php endif; ?>
             <div class="waki-entry-main" title="<?php echo esc_attr($title.' — '.$artist); ?>">
               <div class="ttl"><?php echo esc_html($title); ?></div>


### PR DESCRIPTION
## Summary
- populate chart thumbnail alt text with track title and artist

## Testing
- `php -l includes/class-waki-charts.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b88b2a838c832cb61f9d62b264fbff